### PR TITLE
Allow configuration of the error class used for unwrap_or_raise!

### DIFF
--- a/lib/dry/monads/result.rb
+++ b/lib/dry/monads/result.rb
@@ -24,7 +24,7 @@ module Dry
       attr_reader :failure
 
       class Configuration
-        attr_accessor :before_raise
+        attr_accessor :error_class
       end
 
       class << self
@@ -316,11 +316,9 @@ module Dry
         end
 
         def unwrap_or_raise!
-          if Result.configuration.before_raise
-            Result.configuration.before_raise.call(failure)
-          end
+          error_class = Result.configuration.error_class&.call(failure) || StandardError
 
-          error = StandardError.new(failure)
+          error = error_class.new(failure)
           error.set_backtrace(trace)
           raise error
         end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -517,7 +517,7 @@ RSpec.describe(Dry::Monads::Result) do
       it "raises the failure value as a StandardError" do
         expect { subject.unwrap_or_raise! }.to(raise_error { |error|
           expect(error).to be_a StandardError
-          expect(error.message).to eq('bar')
+          expect(error.message).to eq("bar")
         })
       end
 
@@ -530,9 +530,9 @@ RSpec.describe(Dry::Monads::Result) do
 
         it "allows configuring the error class" do
           Dry::Monads::Result.configure do |config|
-            config.error_class = ->(failure) do
-              case failure
-              in "bar"
+            config.error_class = ->(failure_value) do
+              case failure_value
+              when "bar"
                 ArgumentError
               else
                 RuntimeError
@@ -542,11 +542,11 @@ RSpec.describe(Dry::Monads::Result) do
 
           expect { subject.unwrap_or_raise! }.to(raise_error { |error|
             expect(error).to be_a ArgumentError
-            expect(error.message).to eq('bar')
+            expect(error.message).to eq("bar")
           })
           expect { result::Failure.new("foo").to_result.unwrap_or_raise! }.to(raise_error { |error|
             expect(error).to be_a RuntimeError
-            expect(error.message).to eq('foo')
+            expect(error.message).to eq("foo")
           })
         end
       end

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe(Dry::Monads::Result) do
               end
             end
           end
-          
+
           expect { subject.unwrap_or_raise! }.to(raise_error { |error|
             expect(error).to be_a ArgumentError
             expect(error.message).to eq('bar')
@@ -548,10 +548,9 @@ RSpec.describe(Dry::Monads::Result) do
             expect(error).to be_a RuntimeError
             expect(error.message).to eq('foo')
           })
-
-        end        
+        end
       end
-    end    
+    end
 
     # rubocop:disable Style/CaseEquality
     describe "#===" do

--- a/spec/unit/result_spec.rb
+++ b/spec/unit/result_spec.rb
@@ -265,6 +265,12 @@ RSpec.describe(Dry::Monads::Result) do
       end
     end
 
+    describe "#unwrap_or_raise!" do
+      it "unwraps the values" do
+        expect(subject.unwrap_or_raise!).to eql("foo")
+      end
+    end
+
     # rubocop:disable Style/CaseEquality
     describe "#===" do
       it "matches on the wrapped value" do
@@ -506,6 +512,36 @@ RSpec.describe(Dry::Monads::Result) do
         })
       end
     end
+
+    describe "#unwrap_or_raise!" do
+      it "raises the failure value as a StandardError" do
+        expect { subject.unwrap_or_raise! }.to(raise_error { |error|
+          expect(error).to be_a StandardError
+          expect(error.message).to eq('bar')
+        })
+      end
+
+      describe "with configuration" do
+        after do
+          Dry::Monads::Result.configure do |config|
+            config.before_raise = nil
+          end
+        end
+
+        it "allows configuring the error" do
+          set_failure = nil
+          Dry::Monads::Result.configure do |config|
+            config.before_raise = ->(failure) { set_failure = failure }
+          end
+          
+          expect { subject.unwrap_or_raise! }.to(raise_error { |error|
+            expect(error).to be_a StandardError
+            expect(error.message).to eq('bar')
+          })
+          expect(set_failure).to eq("bar")
+        end        
+      end
+    end    
 
     # rubocop:disable Style/CaseEquality
     describe "#===" do


### PR DESCRIPTION
This allows configuring a `before_raise` hook which is called with the value of any failure objects called with `.unwrap_or_raise!`.

Exploring an idea around DEV-1256